### PR TITLE
chore: mainnet added netlify redirects config

### DIFF
--- a/packages/app/public/netlify.toml
+++ b/packages/app/public/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+	from = "/*"
+	to = "/index.html"
+    status = 200


### PR DESCRIPTION
# What ❔

This PR adds netlify [config](https://docs.netlify.com/routing/redirects/) to redirect all requests into `index.html` and avoid 404s

## Why ❔

Prevent issues with redirects 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
