### PR TITLE
feat: add network switching

### DIFF
--- a/packages/app/src/components/NetworkSwitch.vue
+++ b/packages/app/src/components/NetworkSwitch.vue
@@ -62,7 +62,11 @@ const getNetworkUrl = (network: NetworkConfig) => {
   const hostname = getWindowLocation().hostname;
 
   if (hostname === "localhost" || hostname.endsWith("web.app") || !network.hostnames?.length) {
-    return `${route.path}?network=${network.name}`;
+    // Switch networks within same domain
+    // return `${route.path}?network=${network.name}`;
+
+    // Switch networks by going to different domain
+    return `${network.hostnames[0]}${route.path}`;
   }
   return network.hostnames[0] + route.path;
 };
@@ -93,7 +97,7 @@ const getNetworkUrl = (network: NetworkConfig) => {
     }
 
     .network-list-item {
-      @apply w-full font-sans text-base font-normal text-cream no-underline;
+      @apply w-full font-sans text-base font-normal text-cream no-underline flex flex-row items-center;
       &:not(.selected) {
         cursor: pointer;
       }
@@ -104,7 +108,7 @@ const getNetworkUrl = (network: NetworkConfig) => {
     @apply relative flex w-full min-w-[125px] items-center rounded-md border border-night-800 bg-night-1000 px-2 py-2 font-sans text-base text-silver-500 hover:cursor-pointer focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 lg:border-primary-800 lg:bg-primary-800 lg:text-white;
   }
   .network-item {
-    @apply mr-4 flex items-center gap-1;
+    @apply mr-4 flex flex-auto items-center gap-1;
     .network-item-img {
       @apply h-4 w-4 flex-shrink-0;
     }
@@ -119,6 +123,10 @@ const getNetworkUrl = (network: NetworkConfig) => {
     .toggle-button-icon {
       @apply h-5 w-5 text-silver-500 lg:text-white;
     }
+  }
+
+  .maintenance-icon {
+    @apply h-4 w-4 text-silver-500;
   }
 }
 </style>

--- a/packages/app/src/configs/hyperchain.config.json
+++ b/packages/app/src/configs/hyperchain.config.json
@@ -10,9 +10,24 @@
       "l2ChainId": 61166,
       "l2NetworkName": "Treasure",
       "maintenance": false,
-      "name": "Treasure",
+      "name": "treasure",
       "published": true,
       "rpcUrl": "https://rpc.treasure.lol",
+      "baseTokenAddress": "0x000000000000000000000000000000000000800A"
+    },
+    {
+      "apiUrl": "https://block-explorer.topaz.treasurescan.io",
+      "verificationApiUrl": "https://rpc-explorer-verify.topaz.treasure.lol",
+      "bridgeUrl": "https://app.treasure.lol/chain/bridge",
+      "hostnames": ["https://topaz.treasurescan.io"],
+      "icon": "https://ipfs.filebase.io/ipfs/QmT9TS1vsxxq4pToEXPouuYtDcpQZWZfh91NZdNXVQGPrY",
+      "l1ExplorerUrl": "https://sepolia.etherscan.io/",
+      "l2ChainId": 978658,
+      "l2NetworkName": "Treasure Topaz",
+      "maintenance": false,
+      "name": "treasureTopaz",
+      "published": true,
+      "rpcUrl": "https://rpc.topaz.treasure.lol",
       "baseTokenAddress": "0x000000000000000000000000000000000000800A"
     }
   ]


### PR DESCRIPTION
Add ability to go from `treasure` <> `treasureTopaz` within ui
<img width="359" alt="image" src="https://github.com/user-attachments/assets/3ef6e925-76d8-42c3-b719-2a436e07eb90">

behavior:
- redirects between `treasurescan.io` and `topaz.treasurecan.io` (+ whatever route.path you are on)

# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
