### PR TITLE
fix: fee faq links

### DIFF
--- a/packages/app/src/components/FeeData.vue
+++ b/packages/app/src/components/FeeData.vue
@@ -27,7 +27,7 @@
       <div>
         <a
           class="refunded-link"
-          href="https://docs.zksync.io/build/developer-reference/fee-model.html#refunds"
+          href="https://docs.zksync.io/zksync-protocol/rollup/fee-model/fee-structure#refunds"
           target="_blank"
           >{{
             t(
@@ -40,7 +40,7 @@
         <a
           v-if="feeData?.isPaidByPaymaster"
           class="paymaster-link"
-          href="https://docs.zksync.io/build/developer-reference/account-abstraction.html#paymasters"
+          href="https://docs.zksync.io/zksync-protocol/account-abstraction/paymasters"
           target="_blank"
           >{{ t("transactions.table.feeDetails.whatIsPaymaster") }}</a
         >

--- a/packages/app/tests/components/FeeData.spec.ts
+++ b/packages/app/tests/components/FeeData.spec.ts
@@ -189,7 +189,7 @@ describe("FeeToken", () => {
       await fireEvent.click(container.querySelector(".toggle-button")!);
       const link = container.querySelector(".refunded-link");
       expect(link?.getAttribute("href")).toBe(
-        "https://docs.zksync.io/build/developer-reference/fee-model.html#refunds"
+        "https://docs.zksync.io/zksync-protocol/rollup/fee-model/fee-structure#refunds"
       );
       expect(link?.getAttribute("target")).toBe("_blank");
       expect(link?.textContent).toBe("Why am I being refunded?");
@@ -240,14 +240,14 @@ describe("FeeToken", () => {
 
       const refundedLink = container.querySelector(".refunded-link");
       expect(refundedLink?.getAttribute("href")).toBe(
-        "https://docs.zksync.io/build/developer-reference/fee-model.html#refunds"
+        "https://docs.zksync.io/zksync-protocol/rollup/fee-model/fee-structure#refunds"
       );
       expect(refundedLink?.getAttribute("target")).toBe("_blank");
       expect(refundedLink?.textContent).toBe("Why is Paymaster being refunded?");
 
       const paymasterLink = container.querySelector(".paymaster-link");
       expect(paymasterLink?.getAttribute("href")).toBe(
-        "https://docs.zksync.io/build/developer-reference/account-abstraction.html#paymasters"
+        "https://docs.zksync.io/zksync-protocol/account-abstraction/paymasters"
       );
       expect(paymasterLink?.getAttribute("target")).toBe("_blank");
       expect(paymasterLink?.textContent).toBe("What is Paymaster?");


### PR DESCRIPTION
Fixes the FAQ links on fee refunds and paymasters going to irrelevant pages