### PR TITLE
feat: add smolcoin override to show token icon

### DIFF
--- a/packages/app/src/components/TokenIconLabel.vue
+++ b/packages/app/src/components/TokenIconLabel.vue
@@ -69,6 +69,10 @@ const props = defineProps({
 });
 
 const imgSource = computed(() => {
+  if (props.symbol == "SMOL") {
+    return "https://assets.coingecko.com/coins/images/33951/standard/Smol_Coin_Icon.png?1703558329";
+  }
+
   return props.iconUrl || "/images/currencies/customToken.svg";
 });
 const { isReady: isImageLoaded } = useImage({ src: imgSource.value });

--- a/packages/app/src/components/TokenIconLabel.vue
+++ b/packages/app/src/components/TokenIconLabel.vue
@@ -69,7 +69,7 @@ const props = defineProps({
 });
 
 const imgSource = computed(() => {
-  if (props.symbol == "SMOL") {
+  if (props.address == "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641") {
     return "https://assets.coingecko.com/coins/images/33951/standard/Smol_Coin_Icon.png?1703558329";
   }
 


### PR DESCRIPTION
# What ❔

Add temp override to show SMOL icon as dependent on offchain service.
<img width="619" alt="image" src="https://github.com/user-attachments/assets/75d1f544-2880-4421-96a0-a0b286cb3e41" />
